### PR TITLE
Update link to OSM Americana repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,6 @@ Map style for the SRVIVRS [Black Pearl project](https://www.srvivrs.org/srvivrs-
 
 [🗺 View the map - dark mode](https://streetferret.github.io/blackpearl-map/?mode=dark)
 
-Derived from the CC0 [OpenStreetMap Americana](https://github.com/ZeLonewolf/openstreetmap-americana) project.
+Derived from the CC0 [OpenStreetMap Americana](https://github.com/osm-americana/openstreetmap-americana) project.
 
 Black Pearl artwork (c) 2024 SRVIVRS


### PR DESCRIPTION
Updated a link to the OpenStreetMap Americana repository that broke following osm-americana/openstreetmap-americana#1187.